### PR TITLE
Fixed server get route for production and development in server.js.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -65,9 +65,10 @@ app.use(express.json());
 // if we're in production, serve client/build as static assets
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '../client/build')));
-}
-
-app.get('*', (req, res) => res.sendFile(path.join(__dirname, '../client/build/index.html')));
+  app.get('*', (req, res) => res.sendFile(path.join(__dirname, '../client/build/index.html')));
+} else {
+  app.get('/', (req, res) => res.sendFile(path.join(__dirname, '../client/build/index.html')));
+};
 
 
 const startApolloServer = async () => {


### PR DESCRIPTION
Fix for server.js now works in development and production to use graphical route for graphql.